### PR TITLE
Fixed creating new multi-valued property

### DIFF
--- a/src/main/java/co/acu/pagetool/crx/SlingClient.java
+++ b/src/main/java/co/acu/pagetool/crx/SlingClient.java
@@ -214,11 +214,11 @@ public class SlingClient {
                             params.add(new BasicNameValuePair(updateProp.getName() + SlingPostConstants.TYPE_HINT_SUFFIX, "String[]"));
                             params.add(new BasicNameValuePair(updateProp.getName(), updateProp.getValues()[0]));
                         }
-                    }
-                } else if (updateProp.isMulti()) {
-                    params.add(new BasicNameValuePair(updateProp.getName() + SlingPostConstants.TYPE_HINT_SUFFIX, "String[]"));
-                    for (String value : updateProp.getValues()) {
-                        params.add(new BasicNameValuePair(updateProp.getName(), value));
+                    } else {
+                        params.add(new BasicNameValuePair(updateProp.getName() + SlingPostConstants.TYPE_HINT_SUFFIX, "String[]"));
+                        for (String value : updateProp.getValues()) {
+                            params.add(new BasicNameValuePair(updateProp.getName(), value));
+                        }
                     }
                 } else {
                     params.add(new BasicNameValuePair(updateProp.getName(), updateProp.getValue()));


### PR DESCRIPTION
When creating a multi-valued property and the property didn't exist, the process was failing silently